### PR TITLE
Multiple fixes to dns_fornex.sh 

### DIFF
--- a/dnsapi/dns_fornex.sh
+++ b/dnsapi/dns_fornex.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env sh
 # shellcheck disable=SC2034
+
 dns_fornex_info='Fornex.com
 Site: Fornex.com
 Docs: github.com/acmesh-official/acme.sh/wiki/dnsapi2#dns_fornex
 Options:
  FORNEX_API_KEY API Key
+ FORNEX_API_URL Optional API base URL (default: https://fornex.com/api)
 Issues: github.com/acmesh-official/acme.sh/issues/3998
 Author: Timur Umarov <inbox@tumarov.com>
+Patched for redirect-safe Authorization handling, exact root-domain detection,
+correct subdomain TXT host handling, and reliable TXT cleanup.
 '
 
-FORNEX_API_URL="https://fornex.com/api"
+FORNEX_API_URL_DEFAULT="https://fornex.com/api"
 
 ########  Public functions #####################
 
-#Usage: dns_fornex_add   _acme-challenge.www.domain.com   "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
+# Usage: dns_fornex_add _acme-challenge.www.domain.com "txt-value"
 dns_fornex_add() {
   fulldomain=$1
   txtvalue=$2
@@ -27,19 +31,21 @@ dns_fornex_add() {
     return 1
   else
     _debug _domain "$_domain"
+    _debug _sub_domain "$_sub_domain"
   fi
 
-  _info "Adding record"
-  if _rest POST "dns/domain/$_domain/entry_set/" "{\"host\" : \"${fulldomain}\" , \"type\" : \"TXT\" , \"value\" : \"${txtvalue}\" , \"ttl\" : null}"; then
+  _info "Adding TXT record"
+  if _rest POST "dns/domain/$_domain/entry_set/" "{\"host\":\"${_sub_domain}\",\"type\":\"TXT\",\"value\":\"${txtvalue}\",\"ttl\":null}"; then
     _debug _response "$response"
     _info "Added, OK"
     return 0
   fi
+
   _err "Add txt record error."
   return 1
 }
 
-#Usage: dns_fornex_rm   _acme-challenge.www.domain.com
+# Usage: dns_fornex_rm _acme-challenge.www.domain.com "txt-value"
 dns_fornex_rm() {
   fulldomain=$1
   txtvalue=$2
@@ -53,101 +59,173 @@ dns_fornex_rm() {
     return 1
   else
     _debug _domain "$_domain"
+    _debug _sub_domain "$_sub_domain"
   fi
 
-  _debug "Getting txt records"
-  _rest GET "dns/domain/$_domain/entry_set?type=TXT&q=$fulldomain"
+  _debug "Getting TXT records"
+  if ! _rest GET "dns/domain/$_domain/entry_set?type=TXT"; then
+    return 1
+  fi
 
-  if ! _contains "$response" "$txtvalue"; then
+  _record_id="$(_fornex_find_txt_record_id "$response" "$_sub_domain" "$txtvalue")"
+  _debug _record_id "$_record_id"
+
+  if [ -z "$_record_id" ]; then
     _err "Txt record not found"
     return 1
   fi
 
-  _record_id="$(echo "$response" | _egrep_o "\{[^\{]*\"value\"*:*\"$txtvalue\"[^\}]*\}" | sed -n -e 's#.*"id":\([0-9]*\).*#\1#p')"
-  _debug "_record_id" "$_record_id"
-  if [ -z "$_record_id" ]; then
-    _err "can not find _record_id"
-    return 1
-  fi
-
-  if ! _rest DELETE "dns/domain/$_domain/entry_set/$_record_id/"; then
+  if ! _rest DELETE "dns/domain/$_domain/entry_set/$_record_id/" ""; then
     _err "Delete record error."
     return 1
   fi
+
   return 0
 }
 
 ####################  Private functions below ##################################
 
-#_acme-challenge.www.domain.com
-#returns
-# _sub_domain=_acme-challenge.www
-# _domain=domain.com
+# Input:  _acme-challenge.www.domain.com
+# Output:
+#   _sub_domain=_acme-challenge.www
+#   _domain=domain.com
 _get_root() {
   domain=$1
-
   i=1
+
   while true; do
     h=$(printf "%s" "$domain" | cut -d . -f "$i"-100)
     _debug h "$h"
+
     if [ -z "$h" ]; then
-      #not valid
       return 1
     fi
 
-    if ! _rest GET "dns/domain/"; then
-      return 1
-    fi
-
-    if _contains "$response" "\"name\":\"$h\"" >/dev/null; then
-      _domain=$h
+    if _fornex_zone_exists "$h"; then
+      _domain="$h"
+      if [ "$i" -gt 1 ]; then
+        _sub_domain=$(printf "%s" "$domain" | cut -d . -f "1-$((i - 1))")
+      else
+        _sub_domain=""
+      fi
       return 0
-    else
-      _debug "$h not found"
     fi
+
     i=$(_math "$i" + 1)
   done
 
   return 1
 }
 
-_Fornex_API() {
-  FORNEX_API_KEY="${FORNEX_API_KEY:-$(_readaccountconf_mutable FORNEX_API_KEY)}"
-  if [ -z "$FORNEX_API_KEY" ]; then
-    FORNEX_API_KEY=""
+_fornex_zone_exists() {
+  candidate=$1
 
-    _err "You didn't specify the Fornex API key yet."
-    _err "Please create your key and try again."
-
+  if ! _rest GET "dns/domain/?q=$candidate"; then
     return 1
   fi
 
-  _saveaccountconf_mutable FORNEX_API_KEY "$FORNEX_API_KEY"
+  if _contains "$response" "\"detail\":\"No Domain matches the given query.\""; then
+    return 1
+  fi
+
+  if _contains "$response" "\"detail\":\"Not found\""; then
+    return 1
+  fi
+
+  if _contains "$response" "\"detail\":\"Authentication credentials were not provided.\""; then
+    _err "Fornex API authentication failed. Check FORNEX_API_KEY and FORNEX_API_URL."
+    return 1
+  fi
+
+  printf "%s" "$response" | grep -Eq "\"name\"[[:space:]]*:[[:space:]]*\"$candidate\""
 }
 
-#method method action data
+_fornex_find_txt_record_id() {
+  entries_json=$1
+  host=$2
+  value=$3
+
+  printf "%s" "$entries_json" \
+    | tr '{' '\n' \
+    | grep "\"host\":\"$host\"" \
+    | grep '"type":"TXT"' \
+    | grep "\"value\":\"$value\"" \
+    | sed -n 's#.*"id":\([0-9][0-9]*\).*#\1#p' \
+    | head -n 1
+}
+
+_Fornex_API() {
+  FORNEX_API_KEY="${FORNEX_API_KEY:-$(_readaccountconf_mutable FORNEX_API_KEY)}"
+  FORNEX_API_URL="${FORNEX_API_URL:-$(_readaccountconf_mutable FORNEX_API_URL)}"
+
+  if [ -z "$FORNEX_API_KEY" ]; then
+    _err "You didn't specify the Fornex API key yet."
+    _err "Please create your key and try again."
+    return 1
+  fi
+
+  if [ -z "$FORNEX_API_URL" ]; then
+    FORNEX_API_URL="$FORNEX_API_URL_DEFAULT"
+  fi
+
+  _saveaccountconf_mutable FORNEX_API_KEY "$FORNEX_API_KEY"
+  _saveaccountconf_mutable FORNEX_API_URL "$FORNEX_API_URL"
+  return 0
+}
+
+# method endpoint data
 _rest() {
   m=$1
   ep="$2"
   data="$3"
+  url="$FORNEX_API_URL/$ep"
+  AUTH_HEADER="Authorization: Api-Key $FORNEX_API_KEY"
+
   _debug "$ep"
+  _debug url "$url"
 
-  export _H1="Authorization: Api-Key $FORNEX_API_KEY"
-  export _H2="Content-Type: application/json"
-  export _H3="Accept: application/json"
-
-  if [ "$m" != "GET" ]; then
-    _debug data "$data"
-    response="$(_post "$data" "$FORNEX_API_URL/$ep" "" "$m")"
-  else
-    response="$(_get "$FORNEX_API_URL/$ep" | _normalizeJson)"
+  if ! _exists curl; then
+    _err "curl is required for dns_fornex"
+    return 1
   fi
 
-  _ret="$?"
+  if [ "$m" = "GET" ]; then
+    response="$(curl --silent --show-error \
+      --location \
+      --location-trusted \
+      --proto-redir =https \
+      --max-redirs 5 \
+      -H "$AUTH_HEADER" \
+      -H "Accept: application/json" \
+      "$url")"
+  else
+    _debug data "$data"
+    response="$(curl --silent --show-error \
+      --location \
+      --location-trusted \
+      --proto-redir =https \
+      --max-redirs 5 \
+      -X "$m" \
+      -H "$AUTH_HEADER" \
+      -H "Content-Type: application/json" \
+      -H "Accept: application/json" \
+      --data "$data" \
+      "$url")"
+  fi
+  _ret=$?
+
   if [ "$_ret" != "0" ]; then
     _err "error $ep"
     return 1
   fi
+
+  response="$(printf "%s" "$response" | _normalizeJson)"
   _debug2 response "$response"
+
+  if _contains "$response" "\"detail\":\"Authentication credentials were not provided.\""; then
+    _err "Fornex API authentication failed: credentials were not provided."
+    return 1
+  fi
+
   return 0
 }


### PR DESCRIPTION
## Summary

This PR fixes several issues in `dns_fornex.sh` that prevent `acme.sh` DNS-01 validation from working reliably with the current Fornex Public API, especially for subdomains such as `api.example.com`.

## Root causes

1. The hook relied on the original `https://fornex.com/api` endpoint, but depending on geography and routing, the same URL may either return a direct `200 OK` response or redirect to `https://ru.fornex.com/api`.
2. Standard `curl -L` redirect following is not sufficient here because when a redirect crosses hosts, curl does not reliably resend credentials to the redirected host unless explicitly told to trust the redirect target.
3. TXT records were created with `host` set to the full FQDN (for example `_acme-challenge.api.example.com`) instead of the relative host expected by the Fornex DNS API (for example `_acme-challenge.api`).
4. Root zone detection was incomplete for subdomain certificates because `_get_root()` never computed `_sub_domain`, even though the function comment suggested both `_domain` and `_sub_domain` should be derived.
5. TXT record cleanup depended on the `q` filter of the `entry_set` endpoint (in master branch). In practice, this was not reliable enough for exact cleanup of `_acme-challenge` TXT records, so valid TXT records could remain undeleted after successful issuance/renewal.

## What changed

### 1. Kept the default API endpoint as `https://fornex.com/api`

The hook now defaults to:

```sh
FORNEX_API_URL_DEFAULT="https://fornex.com/api"
```

This preserves the provider's canonical public API URL and avoids hard-coding a region-specific hostname.

### 2. Added redirect-safe authentication handling in `curl`

The updated `_rest()` implementation now uses:

```sh
--location
--location-trusted
--proto-redir =https
--max-redirs 5
```

along with the explicit header:

```sh
Authorization: Api-Key $FORNEX_API_KEY
```

This keeps the hook compatible with both behaviors:

- direct `200 OK` responses from `https://fornex.com/api/...`
- redirects from `https://fornex.com/api/...` to `https://ru.fornex.com/api/...`

The `--location-trusted` option is important here because curl otherwise avoids forwarding credentials across host redirects.

The `--proto-redir =https` restriction ensures redirects are followed only to HTTPS URLs.

### 3. Added optional `FORNEX_API_URL`

The hook still supports an overrideable API base URL via:

- `FORNEX_API_KEY`
- `FORNEX_API_URL`

This keeps the endpoint configurable without modifying the hook.

### 4. Reworked `_rest()` to use direct `curl` requests

The original implementation used generic acme.sh HTTP helpers. The updated version uses direct `curl` requests with explicit headers and redirect handling tailored to the Fornex API behavior.

### 5. Fixed TXT record creation for subdomains

The original code used:

```sh
"host" : "${fulldomain}"
```

The updated code uses:

```sh
"host":"${_sub_domain}"
```

For example, when issuing a certificate for `api.example.com`, the hook now correctly creates TXT host `_acme-challenge.api` in the `example.com` zone instead of incorrectly sending the full FQDN as the host.

### 6. Fixed TXT record lookup/removal

The original removal flow queried records with:

```sh
q=$fulldomain
```

An intermediate version queried with:

```sh
q=${_sub_domain}
```

However, in practice the `q` filter on `entry_set` was still not reliable enough for exact TXT cleanup.

The updated code now fetches TXT records for the zone:

```sh
dns/domain/$_domain/entry_set?type=TXT
```

and then matches records locally by exact:

- `host`
- `type`
- `value`

before deleting by `id`.

This makes cleanup deterministic and prevents stale `_acme-challenge` TXT records from being left behind after a successful issuance/renewal.

### 7. Fixed root zone detection

`_get_root()` now:

- iterates over candidate suffixes of the requested `_acme-challenge...` FQDN
- finds the actual managed DNS zone
- sets `_domain`
- computes `_sub_domain`

Example:

- input: `_acme-challenge.api.example.com`
- detected `_domain`: `example.com`
- computed `_sub_domain`: `_acme-challenge.api`

### 8. Added `_fornex_zone_exists()` helper

This helper improves readability and robustness by:

- querying `dns/domain/?q=$candidate`
- rejecting `No Domain matches the given query.` and `Not found`
- surfacing authentication failures explicitly
- accepting only exact zone matches

### 9. Added `_fornex_find_txt_record_id()` helper

This helper extracts the correct DNS record ID from the returned TXT entry list by matching exact `host`, `type`, and `value`, then returns the matching `id` for deletion.

### 10. Improved diagnostics

The updated script logs:

- the resolved API URL
- `_domain`
- `_sub_domain`
- authentication-specific failures
- the matched `_record_id`

This makes troubleshooting much easier.

## Why this is correct

The curl documentation states that when redirects go to another hostname, curl limits what credentials it sends to the following host, and that `--location-trusted` tells curl to also send credentials to the redirected host when that redirect target is trusted.

The curl documentation also documents `--location-trusted` as the option specifically intended for this case.

Using `https://fornex.com/api` as the default while enabling trusted HTTPS redirect handling is therefore a better fit than hard-coding `https://ru.fornex.com/api`, because it supports both the direct-response and redirecting behaviors observed in practice.

The Fornex DNS API also returns entry objects that include `id`, `host`, `type`, and `value`, so exact local matching is safer than depending on the API's `q` filter for cleanup.

## Result

With this patch, `acme.sh` DNS-01 validation works correctly again for Fornex-managed zones, including subdomain certificates such as:

- `api.example.com`
- wildcard or other delegated TXT validations within the parent zone

The hook now:

- authenticates successfully whether `fornex.com/api` answers directly or redirects to `ru.fornex.com/api`
- finds the correct DNS zone
- creates the TXT record using the correct relative host
- removes the TXT record correctly afterward

## Suggested tests

1. Renew/issue a certificate for an apex domain managed in Fornex DNS.
2. Renew/issue a certificate for a subdomain such as `api.example.com`.
3. Confirm that the TXT record is created in the expected parent zone with the expected relative `host`.
4. Confirm that record cleanup succeeds and no stale TXT records remain.
5. Confirm that overriding `FORNEX_API_URL` still works.
6. Confirm that the hook works in both environments where `https://fornex.com/api/...` responds directly and where it redirects to `https://ru.fornex.com/api/...`.
